### PR TITLE
add a proper sleep.

### DIFF
--- a/upstart/stud.conf
+++ b/upstart/stud.conf
@@ -7,4 +7,10 @@ start on runlevel [23]
 respawn
 respawn limit unlimited
 
-exec stud --config /etc/stud/stud.cfg
+script
+  # If this job is failed, upstart supervisor will run again soon. It's too fast.
+  # Therefore a proper sleep is needed.
+  sleep ${SLEEP_SEC:-1}
+
+  exec stud --config /etc/stud/stud.cfg
+end script


### PR DESCRIPTION
### Problem

When stud terminated forever, upstart respawn soon.

```
Apr 24 09:48:45 wwej15a0 init: stud main process (32053) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32055) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32057) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32059) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32061) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32063) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32065) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32067) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32069) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32071) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32073) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
Apr 24 09:48:45 wwej15a0 init: stud main process (32075) terminated with status 1
Apr 24 09:48:45 wwej15a0 init: stud main process ended, respawning
```

When stud is unnecessary case, stud will not start forever.
### Solution

Add a proper sleep time to `script` section.
